### PR TITLE
バイナリサイズを縮小

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -663,6 +663,10 @@ fn gen_binary_source(
     let status = Command::new(program)
         .arg("build")
         .arg(format!("--target={}", target))
+        .arg("-Z")
+        .arg("build-std=std,panic_abort")
+        .arg("-Z")
+        .arg("build-std-features=panic_immediate_abort")
         .arg("--release")
         .arg("--bin")
         .arg(&bin.name)
@@ -697,6 +701,7 @@ fn gen_binary_source(
             println!("upx found. Use upx to compress binary.");
             let status = Command::new(upx_path)
                 .arg("--best")
+                .arg("--lzma")
                 .arg("-qq")
                 .arg(&binary_file)
                 .status()?;


### PR DESCRIPTION
参考：https://github.com/johnthagen/min-sized-rust

```
% cargo atcoder gen-binary a
    Finished release [optimized] target(s) in 0.06s
Built binary size: 53.3 KB
Stripped binary size: 39.2 KB
upx found. Use upx to compress binary.
     39152 ->     17932   45.80%   linux/amd64   a

WARNING: this is an unstable beta version - use for testing only! Really.
Compressed binary size: 17.9 KB
Bundled code size: 25.5 KB
Wrote code to `a-bin.rs`
```

```
% upx --version
upx 4.0.1-git-7f8adaa6e9eb
UCL data compression library 1.03
zlib data compression library 1.2.13
LZMA SDK version 4.43
doctest C++ testing framework version 2.4.9
Copyright (C) 1996-2022 Markus Franz Xaver Johannes Oberhumer
Copyright (C) 1996-2022 Laszlo Molnar
Copyright (C) 2000-2022 John F. Reiser
Copyright (C) 2002-2022 Jens Medoch
Copyright (C) 1995-2022 Jean-loup Gailly and Mark Adler
Copyright (C) 1999-2006 Igor Pavlov
Copyright (C) 2016-2021 Viktor Kirilov
UPX comes with ABSOLUTELY NO WARRANTY; for details type 'upx -L'.
```