### PR TITLE
一時ファイルのディレクトリを環境変数から取得

### DIFF
--- a/data/binary_runner.rs.txt
+++ b/data/binary_runner.rs.txt
@@ -5,10 +5,14 @@ const _: &str = r{{HASH_SIGNS}}"
 "{{HASH_SIGNS}};
 
 fn main() {
-    let exe = "/tmp/bin{{HASH}}";
-    std::io::Write::write_all(&mut std::fs::File::create(exe).unwrap(), &decode(BIN)).unwrap();
-    std::fs::set_permissions(exe, std::os::unix::fs::PermissionsExt::from_mode(0o755)).unwrap();
-    std::process::exit(std::process::Command::new(exe).status().unwrap().code().unwrap())
+    let exe = {
+        let mut path = std::path::PathBuf::from(std::env::temp_dir());
+        path.push("bin{{HASH}}");
+        path
+    };
+    std::io::Write::write_all(&mut std::fs::File::create(&exe).unwrap(), &decode(BIN)).unwrap();
+    std::fs::set_permissions(&exe, std::os::unix::fs::PermissionsExt::from_mode(0o755)).unwrap();
+    std::process::exit(std::process::Command::new(&exe).status().unwrap().code().unwrap())
 }
 
 fn decode(v: &str) -> Vec<u8> {

--- a/data/binary_runner.rs.txt
+++ b/data/binary_runner.rs.txt
@@ -5,11 +5,7 @@ const _: &str = r{{HASH_SIGNS}}"
 "{{HASH_SIGNS}};
 
 fn main() {
-    let exe = {
-        let mut path = std::path::PathBuf::from(std::env::temp_dir());
-        path.push("bin{{HASH}}");
-        path
-    };
+    let exe = std::path::PathBuf::from(std::env::temp_dir()).join("bin{{HASH}}");
     std::io::Write::write_all(&mut std::fs::File::create(&exe).unwrap(), &decode(BIN)).unwrap();
     std::fs::set_permissions(&exe, std::os::unix::fs::PermissionsExt::from_mode(0o755)).unwrap();
     std::process::exit(std::process::Command::new(&exe).status().unwrap().code().unwrap())


### PR DESCRIPTION
Codeforces だと `K:\codeforces73\e0f971a623bf424b18406b1457686d11\run-085ce89b7376d5d89465fcffeb6fbfec\run\tmp6t7cy_k1` のようなディレクトリが使われていて、`codeforces71` `codeforces72` `codeforces73` がその時々で変わるため、ハードコードだと大変。